### PR TITLE
feat(component): add markdown component

### DIFF
--- a/frontend/components/index.ts
+++ b/frontend/components/index.ts
@@ -1,0 +1,3 @@
+import Markdown from './markdown/markdown';
+
+export { Markdown };

--- a/frontend/components/markdown/markdown.css
+++ b/frontend/components/markdown/markdown.css
@@ -1,0 +1,2 @@
+@import url('https://cdn.jsdelivr.net/npm/katex@0.15.1/dist/katex.min.css');
+@import url('https://cdn.jsdelivr.net/npm/highlight.js@11.3.1/styles/atom-one-dark.min.css');

--- a/frontend/components/markdown/markdown.tsx
+++ b/frontend/components/markdown/markdown.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { unified } from 'unified';
+import rehypeHighlight from 'rehype-highlight';
+import rehypeKatex from 'rehype-katex';
+import rehypeReact from 'rehype-react';
+import remarkGemoji from 'remark-gemoji';
+import remarkGfm from 'remark-gfm';
+import remarkMath from 'remark-math';
+import remarkParse from 'remark-parse';
+import remarkRehype from 'remark-rehype';
+import MdEditor from 'react-markdown-editor-lite';
+import { UploadFunc } from 'react-markdown-editor-lite/cjs/share/var';
+import 'react-markdown-editor-lite/lib/index.css';
+
+import './markdown.css';
+
+const MarkdownProcessor = unified()
+  .use(remarkParse)
+  .use(remarkGfm)
+  .use(remarkGemoji)
+  .use(remarkMath)
+  .use(remarkRehype)
+  .use(rehypeKatex)
+  .use(rehypeHighlight)
+  .use(rehypeReact, { createElement: React.createElement })
+  .freeze();
+
+const MarkdownViewer = (text: string) => (
+  <div>{MarkdownProcessor.processSync(text).result}</div>
+);
+
+interface MarkdownProps {
+  content: string;
+  editorStyle?: any;
+  mode: 'view' | 'edit';
+  onChange?: (text: string) => void;
+  onImageUpload?: UploadFunc;
+  onCustomImageUpload?: (event: any) => Promise<{
+    url: string;
+    text?: string | undefined;
+  }>;
+}
+
+const Markdown: React.FC<MarkdownProps> = ({
+  content: value,
+  editorStyle,
+  mode,
+  onChange,
+  onImageUpload,
+  onCustomImageUpload,
+}) => {
+  const handleEditorChange = ({ text }: { text: string; html: string }) => {
+    if (onChange) {
+      onChange(text);
+    }
+  };
+
+  return (
+    <>
+      {mode === 'view' ? (
+        MarkdownViewer(value)
+      ) : (
+        <MdEditor
+          style={editorStyle}
+          value={value}
+          onChange={handleEditorChange}
+          onImageUpload={onImageUpload}
+          onCustomImageUpload={onCustomImageUpload}
+          renderHTML={(text) => MarkdownViewer(text)}
+        />
+      )}
+    </>
+  );
+};
+
+export default Markdown;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,10 +16,19 @@
     "prop-types": "^15.7.2",
     "react": "^17.0.2",
     "react-axios": "^2.0.5",
-    "react-dom": "^17.0.2"
+    "react-dom": "^17.0.2",
+    "react-markdown-editor-lite": "^1.3.2",
+    "rehype-highlight": "^5.0.1",
+    "rehype-katex": "^6.0.2",
+    "rehype-react": "^7.0.3",
+    "remark-gemoji": "^7.0.1",
+    "remark-gfm": "^3.0.1",
+    "remark-math": "^5.1.1",
+    "remark-parse": "^10.0.1",
+    "remark-rehype": "^10.1.0",
+    "unified": "^10.1.1"
   },
   "devDependencies": {
-    "@types/classnames": "^2.3.1",
     "@types/crypto-js": "^4.0.2",
     "@types/react": "17.0.33",
     "eslint": "^8.3.0",


### PR DESCRIPTION
This PR adds a `Markdown` component to render a markdown viewer and editor with `remark`.

## Usage

```typescript
const [content, setContent] = useState("# Hello\n---\n**World**\n");
const [mode, setMode] = useState<"view" | "edit">("view");

const handleMode = () => {
  if (mode === "view") {
    setMode("edit");
  } else {
    setMode("view");
  }
};

// Above can be used in a button to switch the mode

const handleOnChange = (text: string) => {
  setContent(text);
};

<Markdown
  content={content}
  mode={mode}
  editorStyle={{ height: "500px" }}
  onChange={handleOnChange}
/>
```

## Notice

The stylesheet is not concerned for now.